### PR TITLE
Replace 'minus' to 'underscore'

### DIFF
--- a/jboss7_
+++ b/jboss7_
@@ -165,7 +165,8 @@ def configure(op_type):
             print
             # element in data with 'memory' word match
             for el in [x for x in data if re.search('memory', x)]:
-                print "multigraph jboss7_mem.%s" % el
+                el2 = el.replace('-', '_')
+                print "multigraph jboss7_mem.%s" % el2
                 print "graph_title %s" % el
                 print "graph_args --base 1024 -l 0"
                 print "graph_vlabel memory"
@@ -218,7 +219,8 @@ def get_data(op_type):
             print
 
             for el in [x for x in data if re.search('memory', x)]:
-                print "multigraph jboss7_mem.%s" % el
+                el2 = el.replace('-', '_')
+                print "multigraph jboss7_mem.%s" % el2
                 for k, v in data[el].items():
                     print "%s.value %s" % (k, v)
                 print

--- a/jboss7_
+++ b/jboss7_
@@ -165,8 +165,7 @@ def configure(op_type):
             print
             # element in data with 'memory' word match
             for el in [x for x in data if re.search('memory', x)]:
-                el2 = el.replace('-', '_')
-                print "multigraph jboss7_mem.%s" % el2
+                print "multigraph jboss7_mem.%s" % el.replace('-', '_')
                 print "graph_title %s" % el
                 print "graph_args --base 1024 -l 0"
                 print "graph_vlabel memory"
@@ -219,8 +218,7 @@ def get_data(op_type):
             print
 
             for el in [x for x in data if re.search('memory', x)]:
-                el2 = el.replace('-', '_')
-                print "multigraph jboss7_mem.%s" % el2
+                print "multigraph jboss7_mem.%s" % el.replace('-', '_')
                 for k, v in data[el].items():
                     print "%s.value %s" % (k, v)
                 print


### PR DESCRIPTION
Hi, Luka!

Munin cannot parse multigraph ids with 'minus' symbol. I am replaced they to 'underscore' symbol. It is fixed now.